### PR TITLE
ci(workflows): align with playbook conventions

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,0 +1,2 @@
+-P ubuntu-latest=catthehacker/ubuntu:act-latest
+-P ubuntu-24.04-arm=catthehacker/ubuntu:act-latest

--- a/.github/workflows/_cargo-audit.yml
+++ b/.github/workflows/_cargo-audit.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Rust install
+      - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: stable
@@ -36,7 +36,7 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-stable-audit-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Check vulnerabilities & licences (cargo deny)
+      - name: Security – cargo deny
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -47,7 +47,7 @@ jobs:
           mv cargo-deny ~/.cargo/bin/
           cargo deny check
 
-      - name: cargo pants
+      - name: Security – cargo pants
         run: |
           cargo install --locked cargo-pants || true
           cargo pants

--- a/.github/workflows/_cargo-audit.yml
+++ b/.github/workflows/_cargo-audit.yml
@@ -1,4 +1,7 @@
 # Reusable workflow: dependency audit via cargo-deny and cargo-pants.
+#
+# Local (standalone):
+#   act workflow_call -W .github/workflows/_cargo-audit.yml
 
 name: Cargo Audit
 

--- a/.github/workflows/_ci-security.yml
+++ b/.github/workflows/_ci-security.yml
@@ -1,4 +1,7 @@
 # Reusable workflow: CI/CD supply chain security audits.
+#
+# Local (standalone):
+#   act workflow_call -W .github/workflows/_ci-security.yml
 
 name: CI Security
 

--- a/.github/workflows/ci-benchmarks.yml
+++ b/.github/workflows/ci-benchmarks.yml
@@ -1,8 +1,14 @@
+# Performance benchmarks: parsing, LSP, and validation.
+#
+# Local:
+#   act push -W .github/workflows/ci-benchmarks.yml -j benchmark
+#   act workflow_dispatch -W .github/workflows/ci-benchmarks.yml
+
 name: 'CI: Benchmarks'
 
 on:
   push:
-    branches: [main, staging]
+    branches: [main]
   pull_request:
     branches: [main]
     types: [labeled]

--- a/.github/workflows/ci-benchmarks.yml
+++ b/.github/workflows/ci-benchmarks.yml
@@ -1,5 +1,13 @@
 # Performance benchmarks: parsing, LSP, and validation.
 #
+# Triggers:
+#   - push to main (automatic baseline)
+#   - workflow_dispatch (on-demand, supports branch selection and benchmark type)
+#
+# On-demand for a PR branch:
+#   gh workflow run "CI: Benchmarks" --ref <branch>
+#   gh workflow run "CI: Benchmarks" --ref <branch> -f benchmark_type=parsing
+#
 # Local:
 #   act push -W .github/workflows/ci-benchmarks.yml -j benchmark
 #   act workflow_dispatch -W .github/workflows/ci-benchmarks.yml
@@ -9,9 +17,6 @@ name: 'CI: Benchmarks'
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
-    types: [labeled]
   workflow_dispatch:
     inputs:
       benchmark_type:
@@ -40,12 +45,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
-    # Run on push to main/staging, manual dispatch, or when 'run-benchmarks' label is added to PR
-    if: |
-      github.event_name == 'push' ||
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' && github.event.label.name == 'run-benchmarks')
 
     steps:
       - name: Checkout
@@ -59,7 +58,7 @@ jobs:
           toolchain: stable
 
       - name: Cache crates
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'workflow_dispatch'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         continue-on-error: false
         with:
@@ -84,23 +83,23 @@ jobs:
 
       - name: Bench – parsing
         if: |
+          github.event_name != 'workflow_dispatch' ||
           github.event.inputs.benchmark_type == 'parsing' ||
-          github.event.inputs.benchmark_type == 'all' ||
-          github.event.inputs.benchmark_type == ''
+          github.event.inputs.benchmark_type == 'all'
         run: cargo bench --bench parsing_benchmarks
 
       - name: Bench – LSP
         if: |
+          github.event_name != 'workflow_dispatch' ||
           github.event.inputs.benchmark_type == 'lsp' ||
-          github.event.inputs.benchmark_type == 'all' ||
-          github.event.inputs.benchmark_type == ''
+          github.event.inputs.benchmark_type == 'all'
         run: cargo bench --bench lsp_benchmarks
 
       - name: Bench – validation
         if: |
+          github.event_name != 'workflow_dispatch' ||
           github.event.inputs.benchmark_type == 'validation' ||
-          github.event.inputs.benchmark_type == 'all' ||
-          github.event.inputs.benchmark_type == ''
+          github.event.inputs.benchmark_type == 'all'
         run: cargo bench --bench validation_benchmarks
 
       - name: Report – generate summary
@@ -136,37 +135,6 @@ jobs:
             target/criterion/
             *_benchmark_results.json
           retention-days: 1
-
-      - name: Report – comment PR
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          script: |
-            let comment = '## Performance Benchmark Results\n\n';
-            comment += `**Commit:** ${context.sha.substring(0, 7)}\n`;
-            comment += `**Date:** ${new Date().toISOString()}\n\n`;
-
-            comment += '### Summary\n';
-            comment += 'Performance benchmarks have been executed for this PR. ';
-            comment += `Check the [Actions tab](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}) for detailed results.\n\n`;
-
-            comment += '### Key Metrics Tested\n';
-            comment += '- **Parsing Performance**: Single-line and multi-file parsing throughput\n';
-            comment += '- **LSP Operations**: Hover, completion, and validation response times\n';
-            comment += '- **Validation Engine**: Error detection and parameter validation performance\n';
-            comment += '- **Memory Usage**: Resource consumption patterns\n\n';
-
-            comment += '### Performance Targets\n';
-            comment += '- **Parsing**: >1MB/s for typical G-code files\n';
-            comment += '- **LSP Response**: <100ms for files <1MB\n';
-            comment += '- **Memory**: <50MB for typical workloads\n';
-
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: comment
-            });
 
       - name: Report – check thresholds
         run: |
@@ -207,24 +175,3 @@ jobs:
           EOF
 
           python3 check_performance.py
-
-  regression-detection:
-    name: Regression detection
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    needs: benchmark
-    if: github.event_name == 'pull_request' && github.event.label.name == 'run-benchmarks'
-
-    steps:
-      - name: Download results
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: benchmark-results-${{ github.sha }}
-          path: current-results/
-
-      - name: Analyze regressions
-        run: |
-          echo "Analyzing performance regression..."
-          echo "This step would compare current results with baseline results from main branch."
-          echo "Regression detection framework ready"

--- a/.github/workflows/ci-benchmarks.yml
+++ b/.github/workflows/ci-benchmarks.yml
@@ -21,6 +21,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/ci-benchmarks.yml
+++ b/.github/workflows/ci-benchmarks.yml
@@ -70,34 +70,34 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gnuplot
 
-      - name: Generate test files
+      - name: Setup – generate test files
         run: python3 benches/generate_test_files.py
 
       - name: Build (release)
         run: cargo build --release
 
-      - name: 'Bench: parsing'
+      - name: Bench – parsing
         if: |
           github.event.inputs.benchmark_type == 'parsing' ||
           github.event.inputs.benchmark_type == 'all' ||
           github.event.inputs.benchmark_type == ''
         run: cargo bench --bench parsing_benchmarks
 
-      - name: 'Bench: LSP'
+      - name: Bench – LSP
         if: |
           github.event.inputs.benchmark_type == 'lsp' ||
           github.event.inputs.benchmark_type == 'all' ||
           github.event.inputs.benchmark_type == ''
         run: cargo bench --bench lsp_benchmarks
 
-      - name: 'Bench: validation'
+      - name: Bench – validation
         if: |
           github.event.inputs.benchmark_type == 'validation' ||
           github.event.inputs.benchmark_type == 'all' ||
           github.event.inputs.benchmark_type == ''
         run: cargo bench --bench validation_benchmarks
 
-      - name: Generate summary
+      - name: Report – generate summary
         env:
           GITHUB_SHA: ${{ github.sha }}
           GITHUB_REF_NAME: ${{ github.ref_name }}
@@ -121,7 +121,7 @@ jobs:
             echo "See the Actions logs for detailed benchmark results."
           } > benchmark-results/summary.md
 
-      - name: Upload results
+      - name: Report – upload results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: benchmark-results-${{ github.sha }}
@@ -131,7 +131,7 @@ jobs:
             *_benchmark_results.json
           retention-days: 1
 
-      - name: Comment PR
+      - name: Report – comment PR
         if: github.event_name == 'pull_request'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
@@ -162,7 +162,7 @@ jobs:
               body: comment
             });
 
-      - name: Check thresholds
+      - name: Report – check thresholds
         run: |
           echo "Checking performance against defined thresholds..."
 

--- a/.github/workflows/ci-compatibility-matrix.yml
+++ b/.github/workflows/ci-compatibility-matrix.yml
@@ -1,11 +1,15 @@
-# Pre-release testing on staging: multi-version and multi-platform matrix.
+# Compatibility testing: multi-version and multi-platform matrix.
+#
+# Local:
+#   act push -W .github/workflows/ci-compatibility-matrix.yml -j test-versions
+#   act push -W .github/workflows/ci-compatibility-matrix.yml -j test-other-platforms
 
 name: 'CI: Compatibility Matrix'
 
 on:
   push:
     branches:
-      - staging
+      - 'compat/*'
 
 permissions: {}
 
@@ -15,7 +19,7 @@ concurrency:
 
 jobs:
   test-versions:
-    name: Linux (${{ matrix.rust }})
+    name: ubuntu-latest (${{ matrix.rust }})
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ci-compatibility-matrix.yml
+++ b/.github/workflows/ci-compatibility-matrix.yml
@@ -9,6 +9,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test-versions:
     name: Linux (${{ matrix.rust }})

--- a/.github/workflows/ci-compatibility-matrix.yml
+++ b/.github/workflows/ci-compatibility-matrix.yml
@@ -34,11 +34,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Check formatting
+      - name: Quality – cargo fmt
         run: |
           cargo fmt --all -- --check
 
-      - name: Lint
+      - name: Quality – cargo clippy
         run: |
           cargo clippy --all-targets -- -D warnings
 
@@ -77,7 +77,7 @@ jobs:
             target: x86_64-pc-windows-msvc
             rust: stable
     steps:
-      - name: Rust install
+      - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: ${{ matrix.rust }}

--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -1,4 +1,7 @@
-# Code coverage: unconditional on main, label-gated on PRs.
+# Code coverage: unconditional on main, on-demand via workflow_dispatch.
+#
+# On-demand for a PR branch:
+#   gh workflow run "CI: Coverage" --ref <branch>
 #
 # Local:
 #   act push -W .github/workflows/ci-coverage.yml
@@ -9,8 +12,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types: [labeled]
+  workflow_dispatch:
 
 permissions: {}
 
@@ -22,9 +24,6 @@ jobs:
   coverage:
     name: Run coverage
     runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'push' ||
-      (github.event_name == 'pull_request' && github.event.label.name == 'run-coverage')
     permissions:
       contents: read
     steps:

--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -1,4 +1,7 @@
 # Code coverage: unconditional on main, label-gated on PRs.
+#
+# Local:
+#   act push -W .github/workflows/ci-coverage.yml
 
 name: 'CI: Coverage'
 

--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -11,6 +11,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   coverage:
     name: Run coverage

--- a/.github/workflows/ci-essentials.yml
+++ b/.github/workflows/ci-essentials.yml
@@ -49,15 +49,15 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ matrix.rust }}-hash-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Check formatting
+      - name: Quality – cargo fmt
         run: |
           cargo fmt --all -- --check
 
-      - name: Lint
+      - name: Quality – cargo clippy
         run: |
           cargo clippy --all-targets -- -D warnings
 
-      - name: Check commit messages
+      - name: Quality – convco check
         run: |
           git show-ref
           echo Commit message: "$(git log -1 --pretty=%B)"
@@ -82,7 +82,7 @@ jobs:
       - name: Test
         run: ./ci/test_full.sh
 
-      - name: Test CLI help output
+      - name: Test – CLI help output
         run: ./target/release/gcode-ls --help
 
   changes:
@@ -94,10 +94,12 @@ jobs:
       cargo_lock: ${{ steps.filter.outputs.cargo_lock }}
       workflows: ${{ steps.filter.outputs.workflows }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - id: filter
+      - name: Filter changed paths
+        id: filter
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
           filters: |

--- a/.github/workflows/ci-essentials.yml
+++ b/.github/workflows/ci-essentials.yml
@@ -9,6 +9,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Build & test

--- a/.github/workflows/ci-essentials.yml
+++ b/.github/workflows/ci-essentials.yml
@@ -1,4 +1,8 @@
 # Any commit on main & PRs
+#
+# Local:
+#   act push -W .github/workflows/ci-essentials.yml -j test
+#   act push -W .github/workflows/ci-essentials.yml -j changes
 
 name: 'CI: Essentials'
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,9 @@
+# Tag-triggered release: build multi-platform binaries and publish.
+#
+# Local:
+#   act push -W .github/workflows/release.yml -j prepare-artifacts
+#   act push -W .github/workflows/release.yml -j release
+
 name: Release
 on:
   push:
@@ -114,6 +120,7 @@ jobs:
   release:
     name: Publish release
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.run_id }}
+  cancel-in-progress: false
+
 jobs:
   prepare-artifacts:
     name: Build artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Build (release)
         run: cargo build --release
 
-      - name: Prepare plain binary
+      - name: Package – prepare binary
         env:
           SUFFIX: ${{ matrix.suffix }}
           GH_OS: ${{ matrix.gh_os }}
@@ -77,7 +77,7 @@ jobs:
         run: cp "target/release/gcode-ls${SUFFIX}" "gcode-ls-${GH_OS}-${GH_ARCH}${SUFFIX}"
         shell: bash
 
-      - name: Compress to zip (macOS/Windows)
+      - name: Package – compress (zip)
         if: matrix.archive_ext == 'zip'
         env:
           TARGET: ${{ matrix.target }}
@@ -88,7 +88,7 @@ jobs:
           zip -A "gcode-ls-${TARGET}.${ARCHIVE_EXT}" "gcode-ls${SUFFIX}"
         shell: bash
 
-      - name: Compress to tar.xz (Linux)
+      - name: Package – compress (tar.xz)
         if: matrix.archive_ext == 'tar.xz'
         env:
           TARGET: ${{ matrix.target }}
@@ -97,14 +97,14 @@ jobs:
           cp "target/release/gcode-ls" .
           tar Jcf "gcode-ls-${TARGET}.${ARCHIVE_EXT}" "gcode-ls"
 
-      - name: Upload archive
+      - name: Upload – archive
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: gcode-ls-${{ matrix.target }}.${{ matrix.archive_ext }}
           path: gcode-ls-${{ matrix.target }}.${{ matrix.archive_ext }}
           retention-days: 1
 
-      - name: Upload binary
+      - name: Upload – binary
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: gcode-ls-${{ matrix.gh_os }}-${{ matrix.gh_arch }}${{ matrix.suffix }}
@@ -140,34 +140,44 @@ jobs:
           ./convco changelog -c .convco --max-versions 1 > CHANGELOG.md
           rm convco convco-ubuntu.zip
 
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Download – archive (x86_64-unknown-linux-gnu)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: gcode-ls-x86_64-unknown-linux-gnu.tar.xz
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Download – archive (aarch64-unknown-linux-gnu)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: gcode-ls-aarch64-unknown-linux-gnu.tar.xz
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Download – archive (aarch64-apple-darwin)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: gcode-ls-aarch64-apple-darwin.zip
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Download – archive (x86_64-apple-darwin)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: gcode-ls-x86_64-apple-darwin.zip
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Download – archive (x86_64-pc-windows-msvc)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: gcode-ls-x86_64-pc-windows-msvc.zip
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Download – binary (linux-amd64)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: gcode-ls-linux-amd64
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Download – binary (linux-arm64)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: gcode-ls-linux-arm64
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Download – binary (darwin-arm64)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: gcode-ls-darwin-arm64
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Download – binary (darwin-amd64)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: gcode-ls-darwin-amd64
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Download – binary (windows-amd64)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: gcode-ls-windows-amd64.exe
 

--- a/.github/workflows/schedule-renovate.yml
+++ b/.github/workflows/schedule-renovate.yml
@@ -7,6 +7,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   renovate:
     name: Run Renovate

--- a/.github/workflows/schedule-supply-chain.yml
+++ b/.github/workflows/schedule-supply-chain.yml
@@ -9,6 +9,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   cargo-audit:
     permissions:

--- a/.github/workflows/schedule-supply-chain.yml
+++ b/.github/workflows/schedule-supply-chain.yml
@@ -1,4 +1,7 @@
 # Scheduled supply chain audits: dependency vulnerabilities and CI security.
+#
+# Local:
+#   act workflow_dispatch -W .github/workflows/schedule-supply-chain.yml
 
 name: 'Schedule: Supply Chain Audit'
 


### PR DESCRIPTION
Bring all workflow files in line with the github-actions-playbook: add
concurrency groups (CI cancels stale PR runs, release and schedules
don't), apply "Category – detail" step-name prefixes for visual
grouping in the Actions UI, and fix a few loose ends — compatibility
matrix now triggers on `compat/*` instead of `staging`, benchmarks drop
the stale `staging` reference, and the release job declares
`environment: release` for secrets scoping.

Also adds `act` invocation commands as header comments in every workflow
and a project-local `.actrc` with runner-label mappings for local
testing.