### PR TITLE
chore: clean up playbook drift after workflow rename

### DIFF
--- a/.github/workflows/schedule-renovate.yml
+++ b/.github/workflows/schedule-renovate.yml
@@ -1,3 +1,8 @@
+# Scheduled Renovate run via GitHub App token.
+#
+# Local:
+#   act workflow_dispatch -W .github/workflows/schedule-renovate.yml
+
 name: 'Schedule: Renovate'
 
 on:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # gcode-language-server
 
 [![release](https://img.shields.io/github/v/release/graelo/gcode-language-server)](https://github.com/graelo/gcode-language-server/releases/latest)
-[![build status](https://github.com/graelo/gcode-language-server/actions/workflows/ci.yml/badge.svg)](https://github.com/graelo/gcode-language-server/actions/workflows/ci.yml)
+[![build status](https://github.com/graelo/gcode-language-server/actions/workflows/ci-essentials.yml/badge.svg)](https://github.com/graelo/gcode-language-server/actions/workflows/ci-essentials.yml)
 [![codecov](https://codecov.io/gh/graelo/gcode-language-server/branch/main/graph/badge.svg)](https://codecov.io/gh/graelo/gcode-language-server)
 [![rust 2021 edition](https://img.shields.io/badge/edition-2021-blue.svg)](https://doc.rust-lang.org/edition-guide/rust-2021/index.html)
 [![license](https://img.shields.io/github/license/graelo/gcode-language-server)](LICENSE)


### PR DESCRIPTION
Two small follow-ups from the recent workflow rename in #20.

The build-status badge in the README still pointed at the removed
`ci.yml` filename, leaving a permanent 404 on the project landing
page. Redirect both halves of the badge URL to `ci-essentials.yml`.

`schedule-renovate.yml` was the only workflow missing the standard
`act` invocation header used by every other file in
`.github/workflows/`, per the playbook's local-simulation convention.
Add the header for consistency.

No behavioral changes; CI workflows themselves are untouched.