### PR TITLE
ci(release): add homebrew formula bump job

### DIFF
--- a/.github/poutine.yml
+++ b/.github/poutine.yml
@@ -5,6 +5,7 @@ skip:
       - pkg:githubactions/dorny/paths-filter
       - pkg:githubactions/zizmorcore/zizmor-action
       - pkg:githubactions/boostsecurityio/poutine-action
+      - pkg:githubactions/mislav/bump-homebrew-formula-action
       - pkg:githubactions/renovatebot/github-action
       - pkg:githubactions/taiki-e/install-action
       - pkg:githubactions/codecov/codecov-action

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@
 # Local:
 #   act push -W .github/workflows/release.yml -j prepare-artifacts
 #   act push -W .github/workflows/release.yml -j release
+#   act push -W .github/workflows/release.yml -j homebrew
 
 name: Release
 on:
@@ -205,3 +206,41 @@ jobs:
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: '*.zip,*.tar.xz'
+
+  homebrew:
+    name: Bump Homebrew formula
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+    needs:
+      - release
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ secrets.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: graelo
+          repositories: homebrew-tap
+
+      - name: Extract version
+        id: extract-version
+        run: |
+          echo "tag-name=${GITHUB_REF#refs/tags/}" >> "${GITHUB_OUTPUT}"
+
+      - uses: mislav/bump-homebrew-formula-action@ccf2332299a883f6af50a1d2d41e5df7904dd769 # v4.1
+        if: '!contains(github.ref, ''-'')' # skip prereleases
+        with:
+          formula-name: gcode-language-server
+          homebrew-tap: graelo/homebrew-tap
+          push-to: graelo/homebrew-tap
+          create-pullrequest: true
+          download-url: https://github.com/graelo/gcode-language-server/archive/refs/tags/${{ steps.extract-version.outputs.tag-name }}.tar.gz
+          commit-message: |
+            {{formulaName}} {{version}}
+
+            Created by https://github.com/mislav/bump-homebrew-formula-action
+        env:
+          COMMITTER_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Add a homebrew job to the release workflow so tagged releases automatically
open a PR against graelo/homebrew-tap to bump the gcode-language-server
formula.

Mirrors the pattern already used in tmux-copyrat: a tap-scoped GitHub App
token (from APP_CLIENT_ID / APP_PRIVATE_KEY in the release environment)
is generated per-run and passed to mislav/bump-homebrew-formula-action via
COMMITTER_TOKEN. push-to bypasses the fork path so the App token (which
lacks GET /user) works. Prereleases (tags containing "-") are skipped.

Prerequisite for the next tag: a Formula/gcode-language-server.rb must
exist in graelo/homebrew-tap — the action only bumps existing formulae.