### PR TITLE
ci(release): build prebuilt binaries via zigbuild matrix

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,2 +1,2 @@
 -P ubuntu-latest=catthehacker/ubuntu:act-latest
--P ubuntu-24.04-arm=catthehacker/ubuntu:act-latest
+--container-architecture linux/amd64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,111 +19,124 @@ concurrency:
 
 jobs:
   prepare-artifacts:
-    name: Build artifacts
+    name: ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
+      id-token: write
+      attestations: write
     strategy:
+      fail-fast: false
       matrix:
         include:
-          - os: macos-latest
-            target: aarch64-apple-darwin
-            gh_os: darwin
-            gh_arch: arm64
-            rust: stable
-            suffix: ''
-            archive_ext: zip
-          - os: macos-15-intel
-            target: x86_64-apple-darwin
-            gh_os: darwin
-            gh_arch: amd64
-            rust: stable
-            suffix: ''
-            archive_ext: zip
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-musl
-            gh_os: linux
-            gh_arch: amd64
-            rust: stable
-            suffix: ''
-            archive_ext: tar.xz
-          - os: ubuntu-24.04-arm
-            target: aarch64-unknown-linux-musl
-            gh_os: linux
-            gh_arch: arm64
-            rust: stable
-            suffix: ''
-            archive_ext: tar.xz
-          - os: windows-latest
-            target: x86_64-pc-windows-msvc
-            gh_os: windows
-            gh_arch: amd64
-            rust: stable
-            suffix: .exe
-            archive_ext: zip
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            builder: zigbuild
+            archive: tar.xz
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+            builder: zigbuild
+            archive: tar.xz
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            builder: zigbuild
+            archive: tar.xz
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            builder: cargo
+            archive: tar.xz
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            builder: cargo
+            archive: zip
+          - target: aarch64-pc-windows-msvc
+            os: windows-11-arm
+            builder: cargo
+            archive: zip
     steps:
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
-        with:
-          toolchain: ${{ matrix.rust }}
-          targets: ${{ matrix.target }}
-
-      - name: Install musl toolchain
-        if: contains(matrix.target, 'linux-musl')
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y musl-tools
-
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
           persist-credentials: false
 
-      - name: Build (release)
-        run: cargo build --release --target=${{ matrix.target }}
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: stable
+          targets: ${{ matrix.target }}
 
-      - name: Package – prepare binary
+      - name: Install cargo-zigbuild
+        if: matrix.builder == 'zigbuild'
+        uses: taiki-e/install-action@1329c298aa20c3257846c9b2e0e55967df3e3c37 # v2.75.25
+        with:
+          tool: cargo-zigbuild@0.22.3
+
+      - name: Build (zigbuild)
+        if: matrix.builder == 'zigbuild'
         env:
-          SUFFIX: ${{ matrix.suffix }}
-          GH_OS: ${{ matrix.gh_os }}
-          GH_ARCH: ${{ matrix.gh_arch }}
           TARGET: ${{ matrix.target }}
-        run: cp "target/${TARGET}/release/gcode-ls${SUFFIX}" "gcode-ls-${GH_OS}-${GH_ARCH}${SUFFIX}"
+        run: cargo zigbuild --release --target "${TARGET}"
+
+      - name: Build (cargo)
+        if: matrix.builder == 'cargo'
+        env:
+          TARGET: ${{ matrix.target }}
+        run: cargo build --release --target "${TARGET}"
+
+      - name: Package
         shell: bash
-
-      - name: Package – compress (zip)
-        if: matrix.archive_ext == 'zip'
         env:
           TARGET: ${{ matrix.target }}
-          ARCHIVE_EXT: ${{ matrix.archive_ext }}
-          SUFFIX: ${{ matrix.suffix }}
+          ARCHIVE_FORMAT: ${{ matrix.archive }}
+          TAG: ${{ github.ref_name }}
+          BIN: gcode-ls
         run: |
-          cp "target/${TARGET}/release/gcode-ls${SUFFIX}" .
-          zip -A "gcode-ls-${TARGET}.${ARCHIVE_EXT}" "gcode-ls${SUFFIX}"
-        shell: bash
+          set -euo pipefail
+          EXT=""
+          if [[ "${TARGET}" == *-windows-* ]]; then
+            EXT=".exe"
+          fi
+          SRC="target/${TARGET}/release/${BIN}${EXT}"
 
-      - name: Package – compress (tar.xz)
-        if: matrix.archive_ext == 'tar.xz'
-        env:
-          TARGET: ${{ matrix.target }}
-          ARCHIVE_EXT: ${{ matrix.archive_ext }}
-        run: |
-          cp "target/${TARGET}/release/gcode-ls" .
-          tar Jcf "gcode-ls-${TARGET}.${ARCHIVE_EXT}" "gcode-ls"
+          STANDALONE="${BIN}-${TARGET}${EXT}"
+          cp "${SRC}" "${STANDALONE}"
+
+          PKG_DIR="${BIN}-${TAG}-${TARGET}"
+          mkdir "${PKG_DIR}"
+          cp "${SRC}" "${PKG_DIR}/"
+          cp README.md LICENSE* "${PKG_DIR}/" 2>/dev/null || true
+
+          if [[ "${ARCHIVE_FORMAT}" == "zip" ]]; then
+            ARCHIVE_FILE="${PKG_DIR}.zip"
+            7z a "${ARCHIVE_FILE}" "${PKG_DIR}" >/dev/null
+          else
+            ARCHIVE_FILE="${PKG_DIR}.tar.xz"
+            tar -cJf "${ARCHIVE_FILE}" "${PKG_DIR}"
+          fi
+
+          echo "STANDALONE=${STANDALONE}" >> "${GITHUB_ENV}"
+          echo "ARCHIVE_FILE=${ARCHIVE_FILE}" >> "${GITHUB_ENV}"
+
+      - name: Attest provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: |
+            ${{ env.STANDALONE }}
+            ${{ env.ARCHIVE_FILE }}
+
+      - name: Upload – standalone
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ env.STANDALONE }}
+          path: ${{ env.STANDALONE }}
+          retention-days: 1
 
       - name: Upload – archive
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: gcode-ls-${{ matrix.target }}.${{ matrix.archive_ext }}
-          path: gcode-ls-${{ matrix.target }}.${{ matrix.archive_ext }}
-          retention-days: 1
-
-      - name: Upload – binary
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: gcode-ls-${{ matrix.gh_os }}-${{ matrix.gh_arch }}${{ matrix.suffix }}
-          path: gcode-ls-${{ matrix.gh_os }}-${{ matrix.gh_arch }}${{ matrix.suffix }}
+          name: ${{ env.ARCHIVE_FILE }}
+          path: ${{ env.ARCHIVE_FILE }}
           retention-days: 1
 
   release:
@@ -132,8 +145,6 @@ jobs:
     environment: release
     permissions:
       contents: write
-      id-token: write
-      attestations: write
     needs:
       - prepare-artifacts
     steps:
@@ -156,46 +167,11 @@ jobs:
           ./convco changelog -c .convco --max-versions 1 > CHANGELOG.md
           rm convco convco-ubuntu.zip
 
-      - name: Download – archive (x86_64-unknown-linux-musl)
+      - name: Download artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: gcode-ls-x86_64-unknown-linux-musl.tar.xz
-      - name: Download – archive (aarch64-unknown-linux-musl)
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: gcode-ls-aarch64-unknown-linux-musl.tar.xz
-      - name: Download – archive (aarch64-apple-darwin)
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: gcode-ls-aarch64-apple-darwin.zip
-      - name: Download – archive (x86_64-apple-darwin)
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: gcode-ls-x86_64-apple-darwin.zip
-      - name: Download – archive (x86_64-pc-windows-msvc)
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: gcode-ls-x86_64-pc-windows-msvc.zip
-      - name: Download – binary (linux-amd64)
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: gcode-ls-linux-amd64
-      - name: Download – binary (linux-arm64)
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: gcode-ls-linux-arm64
-      - name: Download – binary (darwin-arm64)
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: gcode-ls-darwin-arm64
-      - name: Download – binary (darwin-amd64)
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: gcode-ls-darwin-amd64
-      - name: Download – binary (windows-amd64)
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: gcode-ls-windows-amd64.exe
+          path: artifacts
+          merge-multiple: true
 
       - name: Create GitHub release
         env:
@@ -205,22 +181,7 @@ jobs:
           gh release create "${TAG_NAME}" \
             --title "${TAG_NAME}" \
             --notes-file CHANGELOG.md \
-            ./*.zip ./*.tar.xz \
-            ./gcode-ls-linux-amd64 ./gcode-ls-linux-arm64 \
-            ./gcode-ls-darwin-arm64 ./gcode-ls-darwin-amd64 \
-            ./gcode-ls-windows-amd64.exe
-
-      - name: Attest provenance
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
-        with:
-          subject-path: |
-            *.zip
-            *.tar.xz
-            gcode-ls-linux-amd64
-            gcode-ls-linux-arm64
-            gcode-ls-darwin-amd64
-            gcode-ls-darwin-arm64
-            gcode-ls-windows-amd64.exe
+            ./artifacts/*
 
   homebrew:
     name: Bump Homebrew formula
@@ -245,7 +206,8 @@ jobs:
         run: |
           echo "tag-name=${GITHUB_REF#refs/tags/}" >> "${GITHUB_OUTPUT}"
 
-      - uses: mislav/bump-homebrew-formula-action@ccf2332299a883f6af50a1d2d41e5df7904dd769 # v4.1
+      - name: Bump Homebrew formula
+        uses: mislav/bump-homebrew-formula-action@ccf2332299a883f6af50a1d2d41e5df7904dd769 # v4.1
         if: '!contains(github.ref, ''-'')' # skip prereleases
         with:
           formula-name: gcode-language-server

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,14 +41,14 @@ jobs:
             suffix: ''
             archive_ext: zip
           - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
+            target: x86_64-unknown-linux-musl
             gh_os: linux
             gh_arch: amd64
             rust: stable
             suffix: ''
             archive_ext: tar.xz
           - os: ubuntu-24.04-arm
-            target: aarch64-unknown-linux-gnu
+            target: aarch64-unknown-linux-musl
             gh_os: linux
             gh_arch: arm64
             rust: stable
@@ -66,6 +66,13 @@ jobs:
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: ${{ matrix.rust }}
+          targets: ${{ matrix.target }}
+
+      - name: Install musl toolchain
+        if: contains(matrix.target, 'linux-musl')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -74,14 +81,15 @@ jobs:
           persist-credentials: false
 
       - name: Build (release)
-        run: cargo build --release
+        run: cargo build --release --target=${{ matrix.target }}
 
       - name: Package – prepare binary
         env:
           SUFFIX: ${{ matrix.suffix }}
           GH_OS: ${{ matrix.gh_os }}
           GH_ARCH: ${{ matrix.gh_arch }}
-        run: cp "target/release/gcode-ls${SUFFIX}" "gcode-ls-${GH_OS}-${GH_ARCH}${SUFFIX}"
+          TARGET: ${{ matrix.target }}
+        run: cp "target/${TARGET}/release/gcode-ls${SUFFIX}" "gcode-ls-${GH_OS}-${GH_ARCH}${SUFFIX}"
         shell: bash
 
       - name: Package – compress (zip)
@@ -91,7 +99,7 @@ jobs:
           ARCHIVE_EXT: ${{ matrix.archive_ext }}
           SUFFIX: ${{ matrix.suffix }}
         run: |
-          cp "target/release/gcode-ls${SUFFIX}" .
+          cp "target/${TARGET}/release/gcode-ls${SUFFIX}" .
           zip -A "gcode-ls-${TARGET}.${ARCHIVE_EXT}" "gcode-ls${SUFFIX}"
         shell: bash
 
@@ -101,7 +109,7 @@ jobs:
           TARGET: ${{ matrix.target }}
           ARCHIVE_EXT: ${{ matrix.archive_ext }}
         run: |
-          cp "target/release/gcode-ls" .
+          cp "target/${TARGET}/release/gcode-ls" .
           tar Jcf "gcode-ls-${TARGET}.${ARCHIVE_EXT}" "gcode-ls"
 
       - name: Upload – archive
@@ -148,14 +156,14 @@ jobs:
           ./convco changelog -c .convco --max-versions 1 > CHANGELOG.md
           rm convco convco-ubuntu.zip
 
-      - name: Download – archive (x86_64-unknown-linux-gnu)
+      - name: Download – archive (x86_64-unknown-linux-musl)
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: gcode-ls-x86_64-unknown-linux-gnu.tar.xz
-      - name: Download – archive (aarch64-unknown-linux-gnu)
+          name: gcode-ls-x86_64-unknown-linux-musl.tar.xz
+      - name: Download – archive (aarch64-unknown-linux-musl)
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: gcode-ls-aarch64-unknown-linux-gnu.tar.xz
+          name: gcode-ls-aarch64-unknown-linux-musl.tar.xz
       - name: Download – archive (aarch64-apple-darwin)
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -205,7 +213,14 @@ jobs:
       - name: Attest provenance
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
-          subject-path: '*.zip,*.tar.xz'
+          subject-path: |
+            *.zip
+            *.tar.xz
+            gcode-ls-linux-amd64
+            gcode-ls-linux-arm64
+            gcode-ls-darwin-amd64
+            gcode-ls-darwin-arm64
+            gcode-ls-windows-amd64.exe
 
   homebrew:
     name: Bump Homebrew formula


### PR DESCRIPTION
Replace the gnu/native release matrix with the playbook's recipe:
six targets covering Linux musl (amd64+arm64), macOS (Intel+Apple
Silicon), and Windows (amd64+arm64), all cross-compiled through
cargo-zigbuild where the host can't build natively. This unblocks
Mason and similar package managers that expect a static-musl Linux
binary, and brings full Windows arm64 coverage.

Asset names now include the target triple — standalone is
gcode-ls-<target>[.exe], archive is
gcode-ls-<tag>-<target>.{tar.xz,zip} and bundles README + LICENSE.
Provenance attestation moved per-target into the build job so it
runs on the same runner that produced the artifact.

Verified the Linux legs locally with act; macOS and Windows legs
will exercise on the next tag.