### PR TITLE
fix(release): native runners, bash everywhere, align compat matrix

### DIFF
--- a/.github/poutine.yml
+++ b/.github/poutine.yml
@@ -8,5 +8,4 @@ skip:
       - pkg:githubactions/mislav/bump-homebrew-formula-action
       - pkg:githubactions/renovatebot/github-action
       - pkg:githubactions/taiki-e/install-action
-      - pkg:githubactions/mlugg/setup-zig
       - pkg:githubactions/codecov/codecov-action

--- a/.github/poutine.yml
+++ b/.github/poutine.yml
@@ -8,4 +8,5 @@ skip:
       - pkg:githubactions/mislav/bump-homebrew-formula-action
       - pkg:githubactions/renovatebot/github-action
       - pkg:githubactions/taiki-e/install-action
+      - pkg:githubactions/mlugg/setup-zig
       - pkg:githubactions/codecov/codecov-action

--- a/.github/workflows/ci-compatibility-matrix.yml
+++ b/.github/workflows/ci-compatibility-matrix.yml
@@ -110,3 +110,45 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash
         run: ./ci/test_full.sh
+
+  test-cross-compile:
+    name: ${{ matrix.target }} (zigbuild)
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+    steps:
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: stable
+          targets: ${{ matrix.target }}
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Zig and cargo-zigbuild
+        uses: taiki-e/install-action@1329c298aa20c3257846c9b2e0e55967df3e3c37 # v2.75.25
+        with:
+          tool: |
+            zig@0.14.1
+            cargo-zigbuild@0.22.3
+
+      - name: Build (zigbuild)
+        env:
+          TARGET: ${{ matrix.target }}
+        run: cargo zigbuild --release --target "${TARGET}"

--- a/.github/workflows/ci-compatibility-matrix.yml
+++ b/.github/workflows/ci-compatibility-matrix.yml
@@ -68,9 +68,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-15-intel
-            target: x86_64-apple-darwin
-            rust: stable
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             rust: stable
@@ -79,6 +76,9 @@ jobs:
             rust: stable
           - os: windows-latest
             target: x86_64-pc-windows-msvc
+            rust: stable
+          - os: windows-11-arm
+            target: aarch64-pc-windows-msvc
             rust: stable
     steps:
       - name: Install Rust

--- a/.github/workflows/ci-compatibility-matrix.yml
+++ b/.github/workflows/ci-compatibility-matrix.yml
@@ -141,12 +141,15 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install Zig and cargo-zigbuild
+      - name: Install Zig
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        with:
+          version: 0.14.1
+
+      - name: Install cargo-zigbuild
         uses: taiki-e/install-action@1329c298aa20c3257846c9b2e0e55967df3e3c37 # v2.75.25
         with:
-          tool: |
-            zig@0.14.1
-            cargo-zigbuild@0.22.3
+          tool: cargo-zigbuild@0.22.3
 
       - name: Build (zigbuild)
         env:

--- a/.github/workflows/ci-compatibility-matrix.yml
+++ b/.github/workflows/ci-compatibility-matrix.yml
@@ -71,6 +71,9 @@ jobs:
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             rust: stable
+          - os: macos-15-intel
+            target: x86_64-apple-darwin
+            rust: stable
           - os: macos-latest
             target: aarch64-apple-darwin
             rust: stable
@@ -110,44 +113,3 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash
         run: ./ci/test_full.sh
-
-  test-cross-compile:
-    name: ${{ matrix.target }} (zigbuild)
-    runs-on: ${{ matrix.os }}
-    permissions:
-      contents: read
-    defaults:
-      run:
-        shell: bash
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: x86_64-apple-darwin
-            os: macos-latest
-    steps:
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
-        with:
-          toolchain: stable
-          targets: ${{ matrix.target }}
-
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Install Zig
-        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
-        with:
-          version: 0.14.1
-
-      - name: Install cargo-zigbuild
-        uses: taiki-e/install-action@1329c298aa20c3257846c9b2e0e55967df3e3c37 # v2.75.25
-        with:
-          tool: cargo-zigbuild@0.22.3
-
-      - name: Build (zigbuild)
-        env:
-          TARGET: ${{ matrix.target }}
-        run: cargo zigbuild --release --target "${TARGET}"

--- a/.github/workflows/ci-compatibility-matrix.yml
+++ b/.github/workflows/ci-compatibility-matrix.yml
@@ -123,10 +123,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - target: x86_64-unknown-linux-musl
-            os: ubuntu-latest
-          - target: aarch64-unknown-linux-musl
-            os: ubuntu-latest
           - target: x86_64-apple-darwin
             os: macos-latest
     steps:

--- a/.github/workflows/ci-compatibility-matrix.yml
+++ b/.github/workflows/ci-compatibility-matrix.yml
@@ -1,8 +1,8 @@
 # Compatibility testing: multi-version and multi-platform matrix.
 #
 # Local:
-#   act push -W .github/workflows/ci-compatibility-matrix.yml -j test-versions
-#   act push -W .github/workflows/ci-compatibility-matrix.yml -j test-other-platforms
+#   act push -W .github/workflows/ci-compatibility-matrix.yml -j test-all-versions
+#   act push -W .github/workflows/ci-compatibility-matrix.yml -j test-all-platforms
 
 name: 'CI: Compatibility Matrix'
 
@@ -18,11 +18,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test-versions:
+  test-all-versions:
     name: ubuntu-latest (${{ matrix.rust }})
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    defaults:
+      run:
+        shell: bash
     strategy:
       matrix:
         rust: ['1.95.0', beta, nightly]
@@ -60,39 +63,49 @@ jobs:
       - name: Test
         run: ./ci/test_full.sh
 
-  test-other-platforms:
-    name: ${{ matrix.os }} (stable)
+  test-all-platforms:
+    name: ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
+    defaults:
+      run:
+        shell: bash
+    env:
+      CARGO_BUILD_TARGET: ${{ matrix.target }}
     strategy:
+      fail-fast: false
       matrix:
         include:
-          - os: ubuntu-24.04-arm
-            target: aarch64-unknown-linux-gnu
-            rust: stable
-          - os: macos-15-intel
-            target: x86_64-apple-darwin
-            rust: stable
-          - os: macos-latest
-            target: aarch64-apple-darwin
-            rust: stable
-          - os: windows-latest
-            target: x86_64-pc-windows-msvc
-            rust: stable
-          - os: windows-11-arm
-            target: aarch64-pc-windows-msvc
-            rust: stable
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-24.04-arm
+          - target: x86_64-apple-darwin
+            os: macos-15-intel
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+          - target: aarch64-pc-windows-msvc
+            os: windows-11-arm
     steps:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
-          toolchain: ${{ matrix.rust }}
+          toolchain: stable
+          targets: ${{ matrix.target }}
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
+      - name: Install musl toolchain
+        if: contains(matrix.target, 'linux-musl')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
 
       - name: Build (dev)
         run: cargo build
@@ -105,11 +118,5 @@ jobs:
         with:
           tool: cargo-nextest@0.9.133
 
-      - name: Test (Unix)
-        if: runner.os != 'Windows'
-        run: ./ci/test_full.sh
-
-      - name: Test (Windows)
-        if: runner.os == 'Windows'
-        shell: bash
+      - name: Test
         run: ./ci/test_full.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,13 +69,17 @@ jobs:
           toolchain: stable
           targets: ${{ matrix.target }}
 
-      - name: Install Zig and cargo-zigbuild
+      - name: Install Zig
+        if: matrix.builder == 'zigbuild'
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        with:
+          version: 0.14.1
+
+      - name: Install cargo-zigbuild
         if: matrix.builder == 'zigbuild'
         uses: taiki-e/install-action@1329c298aa20c3257846c9b2e0e55967df3e3c37 # v2.75.25
         with:
-          tool: |
-            zig@0.14.1
-            cargo-zigbuild@0.22.3
+          tool: cargo-zigbuild@0.22.3
 
       - name: Build (zigbuild)
         if: matrix.builder == 'zigbuild'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,27 +34,21 @@ jobs:
         include:
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
-            builder: cargo
             archive: tar.xz
           - target: aarch64-unknown-linux-musl
             os: ubuntu-24.04-arm
-            builder: cargo
             archive: tar.xz
           - target: x86_64-apple-darwin
-            os: macos-latest
-            builder: zigbuild
+            os: macos-15-intel
             archive: tar.xz
           - target: aarch64-apple-darwin
             os: macos-latest
-            builder: cargo
             archive: tar.xz
           - target: x86_64-pc-windows-msvc
             os: windows-latest
-            builder: cargo
             archive: zip
           - target: aarch64-pc-windows-msvc
             os: windows-11-arm
-            builder: cargo
             archive: zip
     steps:
       - name: Checkout
@@ -75,26 +69,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y musl-tools
 
-      - name: Install Zig
-        if: matrix.builder == 'zigbuild'
-        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
-        with:
-          version: 0.14.1
-
-      - name: Install cargo-zigbuild
-        if: matrix.builder == 'zigbuild'
-        uses: taiki-e/install-action@1329c298aa20c3257846c9b2e0e55967df3e3c37 # v2.75.25
-        with:
-          tool: cargo-zigbuild@0.22.3
-
-      - name: Build (zigbuild)
-        if: matrix.builder == 'zigbuild'
-        env:
-          TARGET: ${{ matrix.target }}
-        run: cargo zigbuild --release --target "${TARGET}"
-
-      - name: Build (cargo)
-        if: matrix.builder == 'cargo'
+      - name: Build (release)
         env:
           TARGET: ${{ matrix.target }}
         run: cargo build --release --target "${TARGET}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,11 +34,11 @@ jobs:
         include:
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
-            builder: zigbuild
+            builder: cargo
             archive: tar.xz
           - target: aarch64-unknown-linux-musl
-            os: ubuntu-latest
-            builder: zigbuild
+            os: ubuntu-24.04-arm
+            builder: cargo
             archive: tar.xz
           - target: x86_64-apple-darwin
             os: macos-latest
@@ -68,6 +68,12 @@ jobs:
         with:
           toolchain: stable
           targets: ${{ matrix.target }}
+
+      - name: Install musl toolchain
+        if: contains(matrix.target, 'linux-musl')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
 
       - name: Install Zig
         if: matrix.builder == 'zigbuild'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,9 @@ jobs:
       contents: read
       id-token: write
       attestations: write
+    defaults:
+      run:
+        shell: bash
     strategy:
       fail-fast: false
       matrix:
@@ -66,11 +69,13 @@ jobs:
           toolchain: stable
           targets: ${{ matrix.target }}
 
-      - name: Install cargo-zigbuild
+      - name: Install Zig and cargo-zigbuild
         if: matrix.builder == 'zigbuild'
         uses: taiki-e/install-action@1329c298aa20c3257846c9b2e0e55967df3e3c37 # v2.75.25
         with:
-          tool: cargo-zigbuild@0.22.3
+          tool: |
+            zig@0.14.1
+            cargo-zigbuild@0.22.3
 
       - name: Build (zigbuild)
         if: matrix.builder == 'zigbuild'
@@ -85,7 +90,6 @@ jobs:
         run: cargo build --release --target "${TARGET}"
 
       - name: Package
-        shell: bash
         env:
           TARGET: ${{ matrix.target }}
           ARCHIVE_FORMAT: ${{ matrix.archive }}


### PR DESCRIPTION
## Summary

Repairs the broken v0.0.1-rc1 release pipeline and brings the compat matrix in line with it.

- **Native runners only** for all 6 release targets: Linux amd64/arm64 (musl via `musl-tools`), macOS amd64/arm64, Windows amd64/arm64. No cross-compilation.
- **`shell: bash` everywhere** via job-level `defaults: run: shell: bash` in both `release.yml` and `ci-compatibility-matrix.yml` — Windows is no longer special-cased.
- **Compat matrix mirrors release**: same 6 targets, same runners, same musl on Linux. `CARGO_BUILD_TARGET` is set at the job level so `cargo` and `ci/test_full.sh` exercise the actual target tuple. Jobs renamed to `test-all-versions` and `test-all-platforms`.

The original rc1 failures were zigbuild not finding zig and Windows pwsh expanding `${TARGET}` to empty. We tried installing zig and scoping zigbuild to the Apple cross-arch case, but ultimately dropped zigbuild because cargo-zigbuild 0.22.3 + zig 0.14.1 doubles the SDK path against the current `macos-latest` SDK — no upstream fix available.

The same patterns are upstreamed into the github-actions-playbook so downstream consumers don't hit these.

## Test plan
- [ ] Push to `compat/*` to validate all 6 platform legs.
- [ ] Cut `v0.0.1-rc2` after merge; verify all 6 release artifacts + provenance attestations land.