### PR TITLE
ci: lock cargo deps and fix Renovate auto-merge

### DIFF
--- a/.github/workflows/_cargo-audit.yml
+++ b/.github/workflows/_cargo-audit.yml
@@ -48,7 +48,7 @@ jobs:
             tar zx --no-anchored cargo-deny --strip-components=1
           chmod +x cargo-deny
           mv cargo-deny ~/.cargo/bin/
-          cargo deny check
+          cargo deny --locked check
 
       - name: Security – cargo pants
         run: |

--- a/.github/workflows/ci-benchmarks.yml
+++ b/.github/workflows/ci-benchmarks.yml
@@ -79,28 +79,28 @@ jobs:
         run: python3 benches/generate_test_files.py
 
       - name: Build (release)
-        run: cargo build --release
+        run: cargo build --locked --release
 
       - name: Bench – parsing
         if: |
           github.event_name != 'workflow_dispatch' ||
           github.event.inputs.benchmark_type == 'parsing' ||
           github.event.inputs.benchmark_type == 'all'
-        run: cargo bench --bench parsing_benchmarks
+        run: cargo bench --locked --bench parsing_benchmarks
 
       - name: Bench – LSP
         if: |
           github.event_name != 'workflow_dispatch' ||
           github.event.inputs.benchmark_type == 'lsp' ||
           github.event.inputs.benchmark_type == 'all'
-        run: cargo bench --bench lsp_benchmarks
+        run: cargo bench --locked --bench lsp_benchmarks
 
       - name: Bench – validation
         if: |
           github.event_name != 'workflow_dispatch' ||
           github.event.inputs.benchmark_type == 'validation' ||
           github.event.inputs.benchmark_type == 'all'
-        run: cargo bench --bench validation_benchmarks
+        run: cargo bench --locked --bench validation_benchmarks
 
       - name: Report – generate summary
         env:

--- a/.github/workflows/ci-compatibility-matrix.yml
+++ b/.github/workflows/ci-compatibility-matrix.yml
@@ -44,13 +44,13 @@ jobs:
 
       - name: Quality – cargo clippy
         run: |
-          cargo clippy --all-targets -- -D warnings
+          cargo clippy --locked --all-targets -- -D warnings
 
       - name: Build (dev)
-        run: cargo build
+        run: cargo build --locked
 
       - name: Build (release)
-        run: cargo build --release
+        run: cargo build --locked --release
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@1329c298aa20c3257846c9b2e0e55967df3e3c37 # v2.75.25
@@ -105,10 +105,10 @@ jobs:
           sudo apt-get install -y musl-tools
 
       - name: Build (dev)
-        run: cargo build
+        run: cargo build --locked
 
       - name: Build (release)
-        run: cargo build --release
+        run: cargo build --locked --release
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@1329c298aa20c3257846c9b2e0e55967df3e3c37 # v2.75.25

--- a/.github/workflows/ci-compatibility-matrix.yml
+++ b/.github/workflows/ci-compatibility-matrix.yml
@@ -23,9 +23,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    defaults:
-      run:
-        shell: bash
     strategy:
       matrix:
         rust: ['1.95.0', beta, nightly]

--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -38,10 +38,10 @@ jobs:
           toolchain: stable
 
       - name: Install cargo-tarpaulin
-        run: cargo install cargo-tarpaulin
+        run: cargo install --locked cargo-tarpaulin
 
       - name: Generate coverage report
-        run: cargo tarpaulin --verbose --timeout 120 --out xml
+        run: cargo tarpaulin --locked --verbose --timeout 120 --out xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0

--- a/.github/workflows/ci-essentials.yml
+++ b/.github/workflows/ci-essentials.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Quality – cargo clippy
         run: |
-          cargo clippy --all-targets -- -D warnings
+          cargo clippy --locked --all-targets -- -D warnings
 
       - name: Quality – convco check
         run: |
@@ -73,10 +73,10 @@ jobs:
           rm convco
 
       - name: Build (dev)
-        run: cargo build
+        run: cargo build --locked
 
       - name: Build (release)
-        run: cargo build --release
+        run: cargo build --locked --release
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@1329c298aa20c3257846c9b2e0e55967df3e3c37 # v2.75.25

--- a/.github/workflows/ci-essentials.yml
+++ b/.github/workflows/ci-essentials.yml
@@ -86,9 +86,6 @@ jobs:
       - name: Test
         run: ./ci/test_full.sh
 
-      - name: Test – CLI help output
-        run: ./target/release/gcode-ls --help
-
   changes:
     name: Detect changes
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Build (release)
         env:
           TARGET: ${{ matrix.target }}
-        run: cargo build --release --target "${TARGET}"
+        run: cargo build --locked --release --target "${TARGET}"
 
       - name: Package
         env:

--- a/ci/test_full.sh
+++ b/ci/test_full.sh
@@ -35,12 +35,12 @@ fi
 set -x
 
 # test the default build
-cargo build
-cargo nextest run $NEXTEST_PROFILE
+cargo build --locked
+cargo nextest run --locked $NEXTEST_PROFILE
 
 # doc tests (not supported by nextest)
-cargo test --doc
+cargo test --locked --doc
 
 # CLI smoke test (release binary)
-cargo build --release
+cargo build --locked --release
 ./target/release/gcode-ls --help

--- a/ci/test_full.sh
+++ b/ci/test_full.sh
@@ -40,3 +40,7 @@ cargo nextest run $NEXTEST_PROFILE
 
 # doc tests (not supported by nextest)
 cargo test --doc
+
+# CLI smoke test (release binary)
+cargo build --release
+./target/release/gcode-ls --help

--- a/ci/test_full.sh
+++ b/ci/test_full.sh
@@ -41,6 +41,13 @@ cargo nextest run --locked $NEXTEST_PROFILE
 # doc tests (not supported by nextest)
 cargo test --locked --doc
 
-# CLI smoke test (release binary)
+# CLI smoke test (release binary). CARGO_BUILD_TARGET (set in the compat
+# matrix) redirects output to target/<target>/release; Git Bash on Windows
+# reports OSTYPE=msys.
 cargo build --locked --release
-./target/release/gcode-ls --help
+
+BIN="target/${CARGO_BUILD_TARGET:+${CARGO_BUILD_TARGET}/}release/gcode-ls"
+case "${OSTYPE:-}" in
+  msys*|cygwin*) BIN="${BIN}.exe" ;;
+esac
+"${BIN}" --help

--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,7 @@
     "enabled": true
   },
   "platformAutomerge": true,
+  "automergeStrategy": "merge-commit",
   "minimumReleaseAge": "3 days",
   "packageRules": [
     {
@@ -22,7 +23,9 @@
     },
     {
       "description": "Group all patch updates into one PR",
-      "matchUpdateTypes": "patch",
+      "matchUpdateTypes": [
+        "patch"
+      ],
       "groupName": "patch updates",
       "automerge": true
     },


### PR DESCRIPTION
Bring the workflows back in line with the GitHub Actions playbook
after its --locked rule and Renovate guidance landed.

Every cargo invocation that resolves deps now passes --locked, so a
stale Cargo.lock fails loudly rather than silently regenerating to
versions that were never tested — including the release build, which
ships the binary. renovate.json was missing
automergeStrategy=merge-commit (Renovate defaulted to squash, which
the main ruleset disallows, so platform auto-merge silently failed),
and the patch packageRule had matchUpdateTypes as a string instead of
an array.

The branch also folds the CLI --help smoke test into ci/test_full.sh
with a CARGO_BUILD_TARGET-aware binary path (the initial fold
hardcoded ./target/release/gcode-ls, which broke every row of the
compat-matrix test-all-platforms job), and drops the explicit bash
default from the linux-only compat job.