### PR TITLE
ci: align workflows with playbook conventions

### DIFF
--- a/.github/workflows/ci-compatibility-matrix.yml
+++ b/.github/workflows/ci-compatibility-matrix.yml
@@ -23,6 +23,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    defaults:
+      run:
+        shell: bash
     strategy:
       matrix:
         rust: ['1.95.0', beta, nightly]
@@ -98,7 +101,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install musl toolchain
+      - name: Install musl-tools (Linux)
         if: contains(matrix.target, 'linux-musl')
         run: |
           sudo apt-get update

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
           toolchain: stable
           targets: ${{ matrix.target }}
 
-      - name: Install musl toolchain
+      - name: Install musl-tools (Linux)
         if: contains(matrix.target, 'linux-musl')
         run: |
           sudo apt-get update
@@ -74,7 +74,7 @@ jobs:
           TARGET: ${{ matrix.target }}
         run: cargo build --locked --release --target "${TARGET}"
 
-      - name: Package
+      - name: Stage binary and archive
         env:
           TARGET: ${{ matrix.target }}
           ARCHIVE_FORMAT: ${{ matrix.archive }}
@@ -114,7 +114,7 @@ jobs:
             ${{ env.STANDALONE }}
             ${{ env.ARCHIVE_FILE }}
 
-      - name: Upload – standalone
+      - name: Upload – binary
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ env.STANDALONE }}
@@ -146,7 +146,6 @@ jobs:
 
       - name: Install convco
         run: |
-          git show-ref
           curl -sSfLO https://github.com/convco/convco/releases/latest/download/convco-ubuntu.zip
           unzip convco-ubuntu.zip
           chmod +x convco

--- a/ci/test_full.sh
+++ b/ci/test_full.sh
@@ -38,6 +38,10 @@ set -x
 cargo build --locked
 cargo nextest run --locked $NEXTEST_PROFILE
 
+# test no-default-features
+cargo build --locked --no-default-features
+cargo nextest run --locked $NEXTEST_PROFILE --no-default-features
+
 # doc tests (not supported by nextest)
 cargo test --locked --doc
 


### PR DESCRIPTION
Audit pass against the github-actions-playbook reference. Most rules
already held; this picks up the drift.

Step names normalized to the canonical set: `Install musl-tools (Linux)`
in both the release and compat-matrix jobs, `Stage binary and archive`
and `Upload – binary` in release. Adds `defaults.shell: bash` to the
test-all-versions matrix so the same `./ci/test_full.sh` line works if
the job ever expands beyond Linux. `ci/test_full.sh` now also runs the
`--no-default-features` build/test pair to match the playbook template.
Drops a stray `git show-ref` debug line left in the release workflow's
`Install convco` step.