### PR TITLE
ci: align matrix jobs with playbook conventions

### DIFF
--- a/.github/workflows/ci-compatibility-matrix.yml
+++ b/.github/workflows/ci-compatibility-matrix.yml
@@ -1,8 +1,8 @@
 # Compatibility testing: multi-version and multi-platform matrix.
 #
 # Local:
-#   act push -W .github/workflows/ci-compatibility-matrix.yml -j test-all-versions
-#   act push -W .github/workflows/ci-compatibility-matrix.yml -j test-all-platforms
+#   act push -W .github/workflows/ci-compatibility-matrix.yml -j test-rust-versions
+#   act push -W .github/workflows/ci-compatibility-matrix.yml -j test-platforms
 
 name: 'CI: Compatibility Matrix'
 
@@ -18,8 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test-all-versions:
-    name: ubuntu-latest (${{ matrix.rust }})
+  test-rust-versions:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -63,8 +62,7 @@ jobs:
       - name: Test
         run: ./ci/test_full.sh
 
-  test-all-platforms:
-    name: ${{ matrix.target }}
+  test-platforms:
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read

--- a/.github/workflows/ci-essentials.yml
+++ b/.github/workflows/ci-essentials.yml
@@ -23,14 +23,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    strategy:
-      matrix:
-        rust: [stable]
     steps:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
-          toolchain: ${{ matrix.rust }}
+          toolchain: stable
           components: rustfmt, clippy
 
       - name: Checkout
@@ -51,7 +48,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ matrix.rust }}-hash-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-stable-hash-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Quality – cargo fmt
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,6 @@ concurrency:
 
 jobs:
   prepare-artifacts:
-    name: ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read


### PR DESCRIPTION
Align matrix jobs in the workflows with the playbook's updated conventions:
drop `name:` overrides so GitHub renders each variant as
`<job-key> (<matrix-values>)`, keeping the YAML key visible in check names
and logs.

Rename generic matrix job keys to describe the dimension they vary —
`test-all-versions` → `test-rust-versions`, `test-all-platforms` →
`test-platforms`. The `prepare-artifacts` key in the release workflow
already followed the convention, only its redundant `name:` is removed.

Also drop the single-value `rust: [stable]` matrix on the essentials test
job and inline the literal value in the toolchain field and cache key.