### PR TITLE
chore: switch renovate automerge strategy to squash

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
     "enabled": true
   },
   "platformAutomerge": true,
-  "automergeStrategy": "merge-commit",
+  "automergeStrategy": "squash",
   "minimumReleaseAge": "3 days",
   "packageRules": [
     {


### PR DESCRIPTION
Change Renovate's automerge strategy from merge-commit to squash. This keeps the main branch history cleaner — dependency updates land as single squashed commits instead of merge commits.